### PR TITLE
Handle LABEL_REPEATED proto Label in type validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 0.8.0 (Unreleased)
+
+BUG FIXES:
+* chrome: fixed a bug where when validating a `googleworkspace_chrome_policy` schema value the proto `LABEL_REPEATED` label was not being respected to require an array of the associated type ([#336](https://github.com/hashicorp/terraform-provider-googleworkspace/pull/336))
+
 ## 0.7.0 (June 10, 2022)
 
 FEATURES:

--- a/internal/provider/resource_chrome_policy.go
+++ b/internal/provider/resource_chrome_policy.go
@@ -357,13 +357,34 @@ func validateChromePolicies(ctx context.Context, d *schema.ResourceData, client 
 					})
 				}
 
-				validType := validatePolicyFieldValueType(schemaField.Type, polVal)
-				if !validType {
-					return append(diags, diag.Diagnostic{
-						Summary:  fmt.Sprintf("value provided for %s is of incorrect type (expected type: %s)", schemaField.Name, schemaField.Type),
-						Severity: diag.Error,
-					})
+				if schemaField.Label == "LABEL_REPEATED" {
+					polValType := reflect.ValueOf(polVal).Kind()
+					if !((polValType == reflect.Array) || (polValType == reflect.Slice)) {
+						return append(diags, diag.Diagnostic{
+							Summary:  fmt.Sprintf("value provided for %s is of incorrect type %v (expected type: []%v)", schemaField.Name, polValType, schemaField.Type),
+							Severity: diag.Error,
+						})
+					} else {
+						if polValArray, ok := polVal.([]interface{}); ok {
+							for _, polValItem := range polValArray {
+								if !validatePolicyFieldValueType(schemaField.Type, polValItem) {
+									return append(diags, diag.Diagnostic{
+										Summary:  fmt.Sprintf("array value %v provided for %s is of incorrect type (expected type: %s)", polValItem, schemaField.Name, schemaField.Type),
+										Severity: diag.Error,
+									})
+								}
+							}
+						}
+					}
+				} else {
+					if !validatePolicyFieldValueType(schemaField.Type, polVal) {
+						return append(diags, diag.Diagnostic{
+							Summary:  fmt.Sprintf("value %v provided for %s is of incorrect type (expected type: %s)", polVal, schemaField.Name, schemaField.Type),
+							Severity: diag.Error,
+						})
+					}
 				}
+
 			}
 		}
 	}


### PR DESCRIPTION
When defining chrome policies and doing the field interpretation the `label` [proto field](https://pkg.go.dev/google.golang.org/api@v0.86.0/chromepolicy/v1#Proto2FieldDescriptorProto) has the option of being returned as a `LABEL_REPEATED` which requires the value to be an array of the defined type.

**This PR fixes the validation function upon the `label` being that `LABEL_REPEATED` option as well as adds some more verbose erroring to call out specific values not complying with the spec.**

An example chrome policy schema with hits this issue is the `chrome.users.UrlBlocking` policy which has the following definition
```json
"definition": {
  "messageType": [
   {
    "field": [
     {
      "label": "LABEL_REPEATED",
      "name": "urlBlocklist",
      "number": 1,
      "type": "TYPE_STRING"
     },
     {
      "label": "LABEL_REPEATED",
      "name": "urlAllowlist",
      "number": 2,
      "type": "TYPE_STRING"
     }
    ],
    "name": "UrlBlocking"
   }
  ]
 }
```

Allowing the following resource definitions to work
```terraform
resource "googleworkspace_org_unit" "bleh" {
  name                 = "bleh"
  parent_org_unit_path = "/"
}

resource "googleworkspace_chrome_policy" "url_blocklist" {
  org_unit_id = googleworkspace_org_unit.bleh.id
  policies {
   schema_name = "chrome.users.UrlBlocking"
   schema_values = {
    urlBlocklist = jsonencode([
        "example.com",
        "bleh.com"
        ])
   } 
  }
}
```