### PR TITLE
Resolve bug in validation of a chrome_policy resource with multiple schema_values of differing types

### DIFF
--- a/internal/provider/resource_chrome_policy.go
+++ b/internal/provider/resource_chrome_policy.go
@@ -564,11 +564,6 @@ func flattenChromePolicies(ctx context.Context, policiesObj []*chromepolicy.Goog
 		}
 
 		schemaFieldMap := map[string]*chromepolicy.Proto2FieldDescriptorProto{}
-
-		// schemaFieldMap = {
-		// 	"details": {def},
-		// 	"smdpAddress": {def}
-		// }
 		for _, schemaField := range schemaDef.Definition.MessageType {
 			for i, schemaNestedField := range schemaField.Field {
 				schemaFieldMap[schemaNestedField.Name] = schemaField.Field[i]

--- a/internal/provider/resource_chrome_policy.go
+++ b/internal/provider/resource_chrome_policy.go
@@ -325,10 +325,10 @@ func validateChromePolicies(ctx context.Context, d *schema.ResourceData, client 
 			})
 		}
 
-		schemaFieldMap := map[string][]*chromepolicy.Proto2FieldDescriptorProto{}
+		schemaFieldMap := map[string]*chromepolicy.Proto2FieldDescriptorProto{}
 		for _, schemaField := range schemaDef.Definition.MessageType {
-			for _, schemaNestedField := range schemaField.Field {
-				schemaFieldMap[schemaNestedField.Name] = schemaField.Field
+			for i, schemaNestedField := range schemaField.Field {
+				schemaFieldMap[schemaNestedField.Name] = schemaField.Field[i]
 			}
 		}
 
@@ -348,43 +348,40 @@ func validateChromePolicies(ctx context.Context, d *schema.ResourceData, client 
 				return diag.FromErr(err)
 			}
 
-			for _, schemaField := range schemaFieldMap[polKey] {
+			schemaField := schemaFieldMap[polKey]
+			if schemaField == nil {
+				return append(diags, diag.Diagnostic{
+					Summary:  fmt.Sprintf("field type is not defined for field name (%s)", polKey),
+					Severity: diag.Warning,
+				})
+			}
 
-				if schemaField == nil {
+			if schemaField.Label == "LABEL_REPEATED" {
+				polValType := reflect.ValueOf(polVal).Kind()
+				if !((polValType == reflect.Array) || (polValType == reflect.Slice)) {
 					return append(diags, diag.Diagnostic{
-						Summary:  fmt.Sprintf("field type is not defined for field name (%s)", polKey),
-						Severity: diag.Warning,
+						Summary:  fmt.Sprintf("value provided for %s is of incorrect type %v (expected type: []%v)", schemaField.Name, polValType, schemaField.Type),
+						Severity: diag.Error,
 					})
-				}
-
-				if schemaField.Label == "LABEL_REPEATED" {
-					polValType := reflect.ValueOf(polVal).Kind()
-					if !((polValType == reflect.Array) || (polValType == reflect.Slice)) {
-						return append(diags, diag.Diagnostic{
-							Summary:  fmt.Sprintf("value provided for %s is of incorrect type %v (expected type: []%v)", schemaField.Name, polValType, schemaField.Type),
-							Severity: diag.Error,
-						})
-					} else {
-						if polValArray, ok := polVal.([]interface{}); ok {
-							for _, polValItem := range polValArray {
-								if !validatePolicyFieldValueType(schemaField.Type, polValItem) {
-									return append(diags, diag.Diagnostic{
-										Summary:  fmt.Sprintf("array value %v provided for %s is of incorrect type (expected type: %s)", polValItem, schemaField.Name, schemaField.Type),
-										Severity: diag.Error,
-									})
-								}
+				} else {
+					if polValArray, ok := polVal.([]interface{}); ok {
+						for _, polValItem := range polValArray {
+							if !validatePolicyFieldValueType(schemaField.Type, polValItem) {
+								return append(diags, diag.Diagnostic{
+									Summary:  fmt.Sprintf("array value %v provided for %s is of incorrect type (expected type: %s)", polValItem, schemaField.Name, schemaField.Type),
+									Severity: diag.Error,
+								})
 							}
 						}
 					}
-				} else {
-					if !validatePolicyFieldValueType(schemaField.Type, polVal) {
-						return append(diags, diag.Diagnostic{
-							Summary:  fmt.Sprintf("value %v provided for %s is of incorrect type (expected type: %s)", polVal, schemaField.Name, schemaField.Type),
-							Severity: diag.Error,
-						})
-					}
 				}
-
+			} else {
+				if !validatePolicyFieldValueType(schemaField.Type, polVal) {
+					return append(diags, diag.Diagnostic{
+						Summary:  fmt.Sprintf("value %v provided for %s is of incorrect type (expected type: %s)", polVal, schemaField.Name, schemaField.Type),
+						Severity: diag.Error,
+					})
+				}
 			}
 		}
 	}
@@ -566,10 +563,15 @@ func flattenChromePolicies(ctx context.Context, policiesObj []*chromepolicy.Goog
 			})
 		}
 
-		schemaFieldMap := map[string][]*chromepolicy.Proto2FieldDescriptorProto{}
+		schemaFieldMap := map[string]*chromepolicy.Proto2FieldDescriptorProto{}
+
+		// schemaFieldMap = {
+		// 	"details": {def},
+		// 	"smdpAddress": {def}
+		// }
 		for _, schemaField := range schemaDef.Definition.MessageType {
-			for _, schemaNestedField := range schemaField.Field {
-				schemaFieldMap[schemaNestedField.Name] = schemaField.Field
+			for i, schemaNestedField := range schemaField.Field {
+				schemaFieldMap[schemaNestedField.Name] = schemaField.Field[i]
 			}
 		}
 
@@ -589,26 +591,24 @@ func flattenChromePolicies(ctx context.Context, policiesObj []*chromepolicy.Goog
 				})
 			}
 
-			for _, schemaField := range schemaFieldMap[k] {
-
-				if schemaField == nil {
-					return nil, append(diags, diag.Diagnostic{
-						Summary:  fmt.Sprintf("field type is not defined for field name (%s)", k),
-						Severity: diag.Warning,
-					})
-				}
-
-				val, err := convertPolicyFieldValueType(schemaField.Type, v)
-				if err != nil {
-					return nil, diag.FromErr(err)
-				}
-
-				jsonVal, err := json.Marshal(val)
-				if err != nil {
-					return nil, diag.FromErr(err)
-				}
-				schemaValues[k] = string(jsonVal)
+			schemaField := schemaFieldMap[k]
+			if schemaField == nil {
+				return nil, append(diags, diag.Diagnostic{
+					Summary:  fmt.Sprintf("field type is not defined for field name (%s)", k),
+					Severity: diag.Warning,
+				})
 			}
+
+			val, err := convertPolicyFieldValueType(schemaField.Type, v)
+			if err != nil {
+				return nil, diag.FromErr(err)
+			}
+
+			jsonVal, err := json.Marshal(val)
+			if err != nil {
+				return nil, diag.FromErr(err)
+			}
+			schemaValues[k] = string(jsonVal)
 		}
 
 		policies = append(policies, map[string]interface{}{

--- a/internal/provider/resource_chrome_policy_test.go
+++ b/internal/provider/resource_chrome_policy_test.go
@@ -169,6 +169,16 @@ func TestAccResourceChromePolicy_multiple(t *testing.T) {
 					testCheck,
 				),
 			},
+			{
+				Config: testAccResourceChromePolicy_multipleValues(ouName, true, "POLICY_MODE_RECOMMENDED"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("googleworkspace_chrome_policy.test", "policies.#", "1"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_policy.test", "policies.0.schema_name", "chrome.users.DomainReliabilityAllowed"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_policy.test", "policies.0.schema_values.domainReliabilityAllowed", "true"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_policy.test", "policies.0.schema_values.domainReliabilityAllowedSettingGroupPolicyMode", encode("POLICY_MODE_RECOMMENDED")),
+					testCheck,
+				),
+			},
 		},
 	})
 }
@@ -251,6 +261,26 @@ resource "googleworkspace_chrome_policy" "test" {
   }
 }
 `, ouName, enabled, pattern)
+}
+
+func testAccResourceChromePolicy_multipleValues(ouName string, enabled bool, policyMode string) string {
+	return fmt.Sprintf(`
+resource "googleworkspace_org_unit" "test" {
+  name = "%s"
+  parent_org_unit_path = "/"
+}
+
+resource "googleworkspace_chrome_policy" "test" {
+  org_unit_id = googleworkspace_org_unit.test.id
+  policies {
+    schema_name = "chrome.users.DomainReliabilityAllowed"
+    schema_values = {
+	  domainReliabilityAllowed                       = jsonencode(%t)
+      domainReliabilityAllowedSettingGroupPolicyMode = jsonencode("%s")
+    }
+  }
+}
+`, ouName, enabled, policyMode)
 }
 
 func testAccResourceChromePolicy_basic(ouName string, conns int) string {

--- a/internal/provider/resource_chrome_policy_test.go
+++ b/internal/provider/resource_chrome_policy_test.go
@@ -170,7 +170,7 @@ func TestAccResourceChromePolicy_multiple(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccResourceChromePolicy_multipleValues(ouName, true, "POLICY_MODE_RECOMMENDED"),
+				Config: testAccResourceChromePolicy_multipleValueTypes(ouName, true, "POLICY_MODE_RECOMMENDED"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("googleworkspace_chrome_policy.test", "policies.#", "1"),
 					resource.TestCheckResourceAttr("googleworkspace_chrome_policy.test", "policies.0.schema_name", "chrome.users.DomainReliabilityAllowed"),

--- a/internal/provider/resource_chrome_policy_test.go
+++ b/internal/provider/resource_chrome_policy_test.go
@@ -263,7 +263,7 @@ resource "googleworkspace_chrome_policy" "test" {
 `, ouName, enabled, pattern)
 }
 
-func testAccResourceChromePolicy_multipleValues(ouName string, enabled bool, policyMode string) string {
+func testAccResourceChromePolicy_multipleValueTypes(ouName string, enabled bool, policyMode string) string {
 	return fmt.Sprintf(`
 resource "googleworkspace_org_unit" "test" {
   name = "%s"


### PR DESCRIPTION
## bug

(Can file issue if preferred - will do on upstream, which also has this bug.)

To reproduce, define a chrome policy resource with two or more schema_values of differing types (on my test workspace, 117 unique policy schemas have this shape*):

```hcl
resource "googleworkspace_chrome_policy" "domain_reliability" {
  org_unit_id = module.base_ou.org_unit_id
  policies {
    schema_name = "chrome.users.DomainReliabilityAllowed"
    schema_values = {
      domainReliabilityAllowedSettingGroupPolicyMode = jsonencode("POLICY_MODE_MANDATORY")
      domainReliabilityAllowed = jsonencode(false)
    }
  }
}
```

 Run `terraform apply`. Expected result:
 
 ```shell
Terraform will perform the following actions:

  # googleworkspace_chrome_policy.domain_reliability will be created
  + resource "googleworkspace_chrome_policy" "domain_reliability" {
      + id          = (known after apply)
      + org_unit_id = "id:redacted"

      + policies {
          + schema_name   = "chrome.users.DomainReliabilityAllowed"
          + schema_values = {
              + "domainReliabilityAllowed"                       = "false"
              + "domainReliabilityAllowedSettingGroupPolicyMode" = "\"POLICY_MODE_MANDATORY\""
            }
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
googleworkspace_chrome_policy.domain_reliability: Creating...
╷
│ Error: value false provided for domainReliabilityAllowedSettingGroupPolicyMode is of incorrect type (expected type: TYPE_ENUM)
│
│   with googleworkspace_chrome_policy.domain_reliability,
│   on main.tf line 37, in resource "googleworkspace_chrome_policy" "domain_reliability":
│   37: resource "googleworkspace_chrome_policy" "domain_reliability" {
```

We're using the wrong nested field definition, and so wrong type, to validate `domainReliabilityAllowedSettingGroupPolicyMode`. Here's the relevant policy schema:

<details>
<summary>chrome.users.DomainReliabilityAllowed</summary>

```json
{
    "name": "customers/redacted/policySchemas/chrome.users.DomainReliabilityAllowed",
    "policyDescription": "Allow reporting of domain reliability related data.",
    "definition": {
        "messageType": [
            {
                "name": "DomainReliabilityAllowed",
                "field": [
                    {
                        "name": "domainReliabilityAllowed",
                        "number": 1,
                        "label": "LABEL_OPTIONAL",
                        "type": "TYPE_BOOL"
                    },
                    {
                        "name": "domainReliabilityAllowedSettingGroupPolicyMode",
                        "number": 9999,
                        "label": "LABEL_OPTIONAL",
                        "type": "TYPE_ENUM",
                        "typeName": "PolicyMode"
                    }
                ]
            }
        ],
        "enumType": [
            {
                "name": "PolicyMode",
                "value": [
                    {
                        "name": "POLICY_MODE_MANDATORY",
                        "number": 1
                    },
                    {
                        "name": "POLICY_MODE_RECOMMENDED",
                        "number": 2
                    }
                ]
            }
        ]
    },
    "fieldDescriptions": [<snipped for length>],
    "schemaName": "chrome.users.DomainReliabilityAllowed",
    "validTargetResources": [
        "ORG_UNIT"
    ],
    "policyApiLifecycle": {
        "policyApiLifecycleStage": "API_DEVELOPMENT"
    },
    "categoryTitle": "Other settings"
}
```

</details>

We're using the entire `messageType[0]["field"]` array, containing >=1 nested field maps, as the schema for each of those nested fields ([L328-L333](https://github.com/Yohan460/terraform-provider-googleworkspace/blob/main/internal/provider/resource_chrome_policy.go#L328-L333)). This causes an erroneous validation against all nested fields' types ([L351](https://github.com/Yohan460/terraform-provider-googleworkspace/blob/main/internal/provider/resource_chrome_policy.go#L351)). If all nested fields don't happen to share the same type, validation will fail as above. If validation somehow passes, the problem would recur at resource creation ([L569-L574](https://github.com/Yohan460/terraform-provider-googleworkspace/blob/main/internal/provider/resource_chrome_policy.go#L569-L574)).

## delta

I've replaced `schemaField.Field` with `schemaNestedField` (accessed with list index), and removed the validation loops. We expect there to always be exactly one nested field schema for any particular nested field. 

This seems reasonable - I don't believe the change breaks an edge case. I've python'd my test workspace's full policy schema and found no nested field schemas whose name conflicts with another's within the same schema. 

But I'm unsure why the validation was first written this way. That's concerning - Chesteron's fence, etc. Git blame points to the [initial commit](https://github.com/hashicorp/terraform-provider-googleworkspace/blame/main/internal/provider/resource_chrome_policy.go#L334) only. It may simply be a mistake which arose from a misunderstanding of (or changes in) schema structure. Or the misunderstanding may turn out to be mine :)!

I've also added a relevant test case**.

### hashicorp upstream?
I'm using this fork, so prioritize fixes here. If this fix is judged sane, is merged, and subsequently fails to delete a large enterprise's workspace, will file with an upstream issue & patch (but won't expect a prompt review ofc).

<details>
  <summary>* policy schemas which support nested fields of differing types</summary>
 
```
chrome.devices.kiosk.AcPowerSettingsV2
chrome.users.SingleSignOnPasswordSynchronization
chrome.users.ChromeBrowserUpdates
chrome.users.JavaScriptJitSettings
chrome.users.UpdatesSuppressed
chrome.users.SecondaryGoogleAccountSignin
chrome.users.RelaunchNotificationWithDuration
chrome.devices.WilcoScheduledUpdate
chrome.users.KerberosTickets
chrome.users.NetworkFileShares
chrome.devices.DeviceWilcoDtc
chrome.users.Homepage
chrome.users.PrintPdfAsImage
chrome.users.ManagedBookmarksSetting
chrome.devices.kiosk.BatteryPowerSettings
chrome.devices.managedguest.WebUsbPortAccess
chrome.devices.DeviceVerifiedMode
chrome.devices.managedguest.IdleSettingsExtended
chrome.devices.kiosk.AcPowerSettings
chrome.users.Cookies
chrome.devices.kiosk.appsconfig.AutoLaunchApp
chrome.users.DnsOverHttps
chrome.devices.EnableGranularDeviceTelemetryReporting
chrome.networks.ethernet.Details
chrome.devices.DeviceScheduledReboot
chrome.users.DefaultPrinters
chrome.devices.EnableGranularDeviceHardwareReporting
chrome.users.WebUsbPortAccess
chrome.users.ChromeCleanupEnabled
chrome.networks.wifi.Details
chrome.users.DomainReliabilityAllowed
chrome.devices.DeviceScreenSettings
chrome.users.SiteIsolationAndroid
chrome.users.WebRtcUdpPortRange
chrome.devices.managedguest.apps.InstallationUrl
chrome.devices.managedguest.ManagedBookmarksSetting
chrome.users.ClipboardSettings
chrome.devices.managedguest.PrintPdfAsImage
chrome.users.AlwaysOnVpn
chrome.devices.managedguest.WebSerialPortAccess
chrome.devices.managedguest.KerberosCustomPrefilledConfigSettingGroup
chrome.devices.EnableGranularDeviceOsReporting
chrome.devices.managedguest.SafeBrowsingProtectionLevel
chrome.devices.managedguest.Notifications
chrome.devices.kiosk.BatteryPowerSettingsV2
chrome.devices.managedguest.ManagedGuestSession
chrome.users.SpellcheckEnabled
chrome.devices.managedguest.FileSystemWrite
chrome.devices.Imprivata
chrome.devices.DeviceLoginScreenAutocompleteDomainGroup
chrome.devices.managedguest.ScreenBrightnessPercent
chrome.devices.managedguest.RemoteAccessHostFirewallTraversal
chrome.devices.managedguest.Popups
chrome.users.KerberosCustomPrefilledConfigSettingGroup
chrome.devices.managedguest.InsecurePrivateNetworkRequestsAllowed
chrome.users.PasswordAlert
chrome.users.FileSystemWrite
chrome.networks.vpn.Details
chrome.devices.managedguest.DefaultSensorsSetting
chrome.devices.managedguest.DefaultPrinters
chrome.users.WebSerialPortAccess
chrome.users.AccessCodeCast
chrome.devices.AdvancedBatteryChargeMode
chrome.users.Javascript
chrome.users.appsconfig.FullRestoreEnabled
chrome.users.StartupPages
chrome.devices.managedguest.NetworkFileShares
chrome.users.SimpleProxySettings
chrome.users.RemoteAccessHostFirewallTraversal
chrome.users.SafeBrowsingProtectionLevel
chrome.users.SyncSettingsCros
chrome.users.DeskApi
chrome.users.IdleSettings
chrome.users.ThirdPartyStoragePartitioningSettings
chrome.devices.ThrottleDeviceBandwidth
chrome.devices.managedguest.AlwaysOnVpn
chrome.devices.SignInRestrictionsOffHours
chrome.devices.PowerPeakShift
chrome.devices.managedguest.ThirdPartyStoragePartitioningSettings
chrome.devices.managedguest.SafeSearchRestrictedMode
chrome.users.SiteIsolationBrowser
chrome.devices.DeviceBatteryCharge
chrome.devices.managedguest.IdleSettings
chrome.devices.InactiveDeviceNotifications
chrome.users.PrintingPaperSizeDefault
chrome.users.ScreenBrightnessPercent
chrome.users.IdleSettingsExtended
chrome.users.Notifications
chrome.devices.managedguest.DnsOverHttps
chrome.devices.managedguest.SimpleProxySettings
chrome.devices.managedguest.JavaScriptJitSettings
chrome.devices.managedguest.SpellcheckEnabled
chrome.devices.Timezone
chrome.users.Popups
chrome.users.appsconfig.ChromeWebStoreHomepage
chrome.devices.SignInRestriction
chrome.devices.managedguest.SecurityTokenSessionSettings
chrome.devices.managedguest.Homepage
chrome.devices.SystemProxySettings
chrome.users.RelaunchNotificationWithDurationV2
chrome.users.Images
chrome.users.apps.InstallationUrl
chrome.devices.AutoUpdateSettings
chrome.users.SecurityTokenSessionSettingsV2
chrome.users.VerifiedMode
chrome.users.SafeSearchRestrictedMode
chrome.users.FileSystemRead
chrome.users.DefaultSensorsSetting
chrome.devices.managedguest.PrintingPaperSizeDefault
chrome.devices.managedguest.StartupPages
chrome.devices.managedguest.ClipboardSettings
chrome.devices.managedguest.FileSystemRead
chrome.users.InsecurePrivateNetworkRequestsAllowed
chrome.users.SyncSettingsCbcm
chrome.devices.kiosk.ManagedGuestSession
chrome.devices.managedguest.SecurityTokenSessionSettingsV2
chrome.users.SecurityTokenSessionSettings
```

  </details>
  
  <details>
  <summary>** eg test failure output</summary>
  
  ```shell
  ==> Checking source code against gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -count=1 $(go list ./...) -v -run=TestAccResourceChromePolicy_multiple -timeout 120m
?   	github.com/hashicorp/terraform-provider-googleworkspace	[no test files]
=== RUN   TestAccResourceChromePolicy_multiple
=== PAUSE TestAccResourceChromePolicy_multiple
=== CONT  TestAccResourceChromePolicy_multiple
    resource_chrome_policy_test.go:137: Step 4/4 error: Error running apply: exit status 1

        Error: value true provided for domainReliabilityAllowedSettingGroupPolicyMode is of incorrect type (expected type: TYPE_ENUM)

          with googleworkspace_chrome_policy.test,
          on terraform_plugin_test.tf line 7, in resource "googleworkspace_chrome_policy" "test":
           7: resource "googleworkspace_chrome_policy" "test" {

--- FAIL: TestAccResourceChromePolicy_multiple (61.61s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-googleworkspace/internal/provider	62.004s
FAIL
make: *** [testacc] Error 1
```

</details>

