### PR TITLE
Additional target keys support

### DIFF
--- a/internal/provider/resource_chrome_policy.go
+++ b/internal/provider/resource_chrome_policy.go
@@ -564,11 +564,6 @@ func flattenChromePolicies(ctx context.Context, policiesObj []*chromepolicy.Goog
 		}
 
 		schemaFieldMap := map[string]*chromepolicy.Proto2FieldDescriptorProto{}
-
-		// schemaFieldMap = {
-		// 	"details": {def},
-		// 	"smdpAddress": {def}
-		// }
 		for _, schemaField := range schemaDef.Definition.MessageType {
 			for i, schemaNestedField := range schemaField.Field {
 				schemaFieldMap[schemaNestedField.Name] = schemaField.Field[i]

--- a/internal/provider/resource_chrome_policy.go
+++ b/internal/provider/resource_chrome_policy.go
@@ -325,10 +325,10 @@ func validateChromePolicies(ctx context.Context, d *schema.ResourceData, client 
 			})
 		}
 
-		schemaFieldMap := map[string][]*chromepolicy.Proto2FieldDescriptorProto{}
+		schemaFieldMap := map[string]*chromepolicy.Proto2FieldDescriptorProto{}
 		for _, schemaField := range schemaDef.Definition.MessageType {
-			for _, schemaNestedField := range schemaField.Field {
-				schemaFieldMap[schemaNestedField.Name] = schemaField.Field
+			for i, schemaNestedField := range schemaField.Field {
+				schemaFieldMap[schemaNestedField.Name] = schemaField.Field[i]
 			}
 		}
 
@@ -348,43 +348,40 @@ func validateChromePolicies(ctx context.Context, d *schema.ResourceData, client 
 				return diag.FromErr(err)
 			}
 
-			for _, schemaField := range schemaFieldMap[polKey] {
+			schemaField := schemaFieldMap[polKey]
+			if schemaField == nil {
+				return append(diags, diag.Diagnostic{
+					Summary:  fmt.Sprintf("field type is not defined for field name (%s)", polKey),
+					Severity: diag.Warning,
+				})
+			}
 
-				if schemaField == nil {
+			if schemaField.Label == "LABEL_REPEATED" {
+				polValType := reflect.ValueOf(polVal).Kind()
+				if !((polValType == reflect.Array) || (polValType == reflect.Slice)) {
 					return append(diags, diag.Diagnostic{
-						Summary:  fmt.Sprintf("field type is not defined for field name (%s)", polKey),
-						Severity: diag.Warning,
+						Summary:  fmt.Sprintf("value provided for %s is of incorrect type %v (expected type: []%v)", schemaField.Name, polValType, schemaField.Type),
+						Severity: diag.Error,
 					})
-				}
-
-				if schemaField.Label == "LABEL_REPEATED" {
-					polValType := reflect.ValueOf(polVal).Kind()
-					if !((polValType == reflect.Array) || (polValType == reflect.Slice)) {
-						return append(diags, diag.Diagnostic{
-							Summary:  fmt.Sprintf("value provided for %s is of incorrect type %v (expected type: []%v)", schemaField.Name, polValType, schemaField.Type),
-							Severity: diag.Error,
-						})
-					} else {
-						if polValArray, ok := polVal.([]interface{}); ok {
-							for _, polValItem := range polValArray {
-								if !validatePolicyFieldValueType(schemaField.Type, polValItem) {
-									return append(diags, diag.Diagnostic{
-										Summary:  fmt.Sprintf("array value %v provided for %s is of incorrect type (expected type: %s)", polValItem, schemaField.Name, schemaField.Type),
-										Severity: diag.Error,
-									})
-								}
+				} else {
+					if polValArray, ok := polVal.([]interface{}); ok {
+						for _, polValItem := range polValArray {
+							if !validatePolicyFieldValueType(schemaField.Type, polValItem) {
+								return append(diags, diag.Diagnostic{
+									Summary:  fmt.Sprintf("array value %v provided for %s is of incorrect type (expected type: %s)", polValItem, schemaField.Name, schemaField.Type),
+									Severity: diag.Error,
+								})
 							}
 						}
 					}
-				} else {
-					if !validatePolicyFieldValueType(schemaField.Type, polVal) {
-						return append(diags, diag.Diagnostic{
-							Summary:  fmt.Sprintf("value %v provided for %s is of incorrect type (expected type: %s)", polVal, schemaField.Name, schemaField.Type),
-							Severity: diag.Error,
-						})
-					}
 				}
-
+			} else {
+				if !validatePolicyFieldValueType(schemaField.Type, polVal) {
+					return append(diags, diag.Diagnostic{
+						Summary:  fmt.Sprintf("value %v provided for %s is of incorrect type (expected type: %s)", polVal, schemaField.Name, schemaField.Type),
+						Severity: diag.Error,
+					})
+				}
 			}
 		}
 	}
@@ -566,10 +563,15 @@ func flattenChromePolicies(ctx context.Context, policiesObj []*chromepolicy.Goog
 			})
 		}
 
-		schemaFieldMap := map[string][]*chromepolicy.Proto2FieldDescriptorProto{}
+		schemaFieldMap := map[string]*chromepolicy.Proto2FieldDescriptorProto{}
+
+		// schemaFieldMap = {
+		// 	"details": {def},
+		// 	"smdpAddress": {def}
+		// }
 		for _, schemaField := range schemaDef.Definition.MessageType {
-			for _, schemaNestedField := range schemaField.Field {
-				schemaFieldMap[schemaNestedField.Name] = schemaField.Field
+			for i, schemaNestedField := range schemaField.Field {
+				schemaFieldMap[schemaNestedField.Name] = schemaField.Field[i]
 			}
 		}
 
@@ -589,26 +591,24 @@ func flattenChromePolicies(ctx context.Context, policiesObj []*chromepolicy.Goog
 				})
 			}
 
-			for _, schemaField := range schemaFieldMap[k] {
-
-				if schemaField == nil {
-					return nil, append(diags, diag.Diagnostic{
-						Summary:  fmt.Sprintf("field type is not defined for field name (%s)", k),
-						Severity: diag.Warning,
-					})
-				}
-
-				val, err := convertPolicyFieldValueType(schemaField.Type, v)
-				if err != nil {
-					return nil, diag.FromErr(err)
-				}
-
-				jsonVal, err := json.Marshal(val)
-				if err != nil {
-					return nil, diag.FromErr(err)
-				}
-				schemaValues[k] = string(jsonVal)
+			schemaField := schemaFieldMap[k]
+			if schemaField == nil {
+				return nil, append(diags, diag.Diagnostic{
+					Summary:  fmt.Sprintf("field type is not defined for field name (%s)", k),
+					Severity: diag.Warning,
+				})
 			}
+
+			val, err := convertPolicyFieldValueType(schemaField.Type, v)
+			if err != nil {
+				return nil, diag.FromErr(err)
+			}
+
+			jsonVal, err := json.Marshal(val)
+			if err != nil {
+				return nil, diag.FromErr(err)
+			}
+			schemaValues[k] = string(jsonVal)
 		}
 
 		policies = append(policies, map[string]interface{}{

--- a/internal/provider/resource_chrome_policy_test.go
+++ b/internal/provider/resource_chrome_policy_test.go
@@ -169,6 +169,16 @@ func TestAccResourceChromePolicy_multiple(t *testing.T) {
 					testCheck,
 				),
 			},
+			{
+				Config: testAccResourceChromePolicy_multipleValues(ouName, true, "POLICY_MODE_RECOMMENDED"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("googleworkspace_chrome_policy.test", "policies.#", "1"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_policy.test", "policies.0.schema_name", "chrome.users.DomainReliabilityAllowed"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_policy.test", "policies.0.schema_values.domainReliabilityAllowed", "true"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_policy.test", "policies.0.schema_values.domainReliabilityAllowedSettingGroupPolicyMode", encode("POLICY_MODE_RECOMMENDED")),
+					testCheck,
+				),
+			},
 		},
 	})
 }
@@ -251,6 +261,26 @@ resource "googleworkspace_chrome_policy" "test" {
   }
 }
 `, ouName, enabled, pattern)
+}
+
+func testAccResourceChromePolicy_multipleValues(ouName string, enabled bool, policyMode string) string {
+	return fmt.Sprintf(`
+resource "googleworkspace_org_unit" "test" {
+  name = "%s"
+  parent_org_unit_path = "/"
+}
+
+resource "googleworkspace_chrome_policy" "test" {
+  org_unit_id = googleworkspace_org_unit.test.id
+  policies {
+    schema_name = "chrome.users.DomainReliabilityAllowed"
+    schema_values = {
+	  domainReliabilityAllowed                       = jsonencode(%t)
+      domainReliabilityAllowedSettingGroupPolicyMode = jsonencode("%s")
+    }
+  }
+}
+`, ouName, enabled, policyMode)
 }
 
 func testAccResourceChromePolicy_basic(ouName string, conns int) string {

--- a/internal/provider/resource_chrome_policy_test.go
+++ b/internal/provider/resource_chrome_policy_test.go
@@ -170,7 +170,7 @@ func TestAccResourceChromePolicy_multiple(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccResourceChromePolicy_multipleValues(ouName, true, "POLICY_MODE_RECOMMENDED"),
+				Config: testAccResourceChromePolicy_multipleValueTypes(ouName, true, "POLICY_MODE_RECOMMENDED"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("googleworkspace_chrome_policy.test", "policies.#", "1"),
 					resource.TestCheckResourceAttr("googleworkspace_chrome_policy.test", "policies.0.schema_name", "chrome.users.DomainReliabilityAllowed"),

--- a/internal/provider/resource_chrome_policy_test.go
+++ b/internal/provider/resource_chrome_policy_test.go
@@ -221,7 +221,7 @@ resource "googleworkspace_org_unit" "test" {
 
 resource "googleworkspace_chrome_policy" "test" {
   org_unit_id = googleworkspace_org_unit.test.id
-  policies {  
+  policies {
     schema_name = "chrome.users.RestrictSigninToPattern"
     schema_values = {
       restrictSigninToPattern = jsonencode("%s")

--- a/internal/provider/resource_chrome_policy_test.go
+++ b/internal/provider/resource_chrome_policy_test.go
@@ -263,7 +263,7 @@ resource "googleworkspace_chrome_policy" "test" {
 `, ouName, enabled, pattern)
 }
 
-func testAccResourceChromePolicy_multipleValues(ouName string, enabled bool, policyMode string) string {
+func testAccResourceChromePolicy_multipleValueTypes(ouName string, enabled bool, policyMode string) string {
 	return fmt.Sprintf(`
 resource "googleworkspace_org_unit" "test" {
   name = "%s"


### PR DESCRIPTION
This PR implements additional target keys support - required for managing extension, app, printer, and wifi network chrome policies.

The implementation uses the existing proto's `AdditionalTargetKeys` attribute: https://pkg.go.dev/google.golang.org/api/chromepolicy/v1#GoogleChromePolicyVersionsV1PolicyTargetKey.AdditionalTargetKeys

I've followed the pattern set by `expandChromePolicyValues` to keep the delta DRY. An update and create test case have been added. The delta & tests work with my dev workspace.

Eg resource defining additional target keys:

```terraform
resource "googleworkspace_chrome_policy" "ublock_managed_configuration" {
  org_unit_id = module.main_ou.org_unit_id

  additional_target_keys {
    target_key   = "app_id"
    target_value = "chrome:cjpalhdlnbpafiamejdnhcphjbkeiagm"
  }

  policies {
    schema_name = "chrome.users.apps.ManagedConfiguration"
    schema_values = {
      managedConfiguration = jsonencode({
        toAdd = {
          Value = {
            trustedSiteDirectives = [
              "corpsite1.co.uk",
            ]
          }
        }
      })
    }
  }
}
```

