### PR TITLE
Add a resource for Chrome Group Policy

### DIFF
--- a/internal/provider/chrome_policy_common.go
+++ b/internal/provider/chrome_policy_common.go
@@ -1,0 +1,266 @@
+package googleworkspace
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"google.golang.org/api/chromepolicy/v1"
+)
+
+// chromePolicyTargetKind represents the resource collection prefix used by the API
+// (currently "orgunits" or "groups").
+type chromePolicyTargetKind string
+
+const (
+	targetOrgUnit chromePolicyTargetKind = "orgunits"
+	targetGroup   chromePolicyTargetKind = "groups"
+)
+
+// chromePolicyCreateCommon contains the shared create logic for both org unit and group chrome policy resources.
+func chromePolicyCreateCommon(ctx context.Context, d *schema.ResourceData, meta interface{}, kind chromePolicyTargetKind, idAttr string) diag.Diagnostics {
+	client := meta.(*apiClient)
+
+	chromePolicyService, diags := client.NewChromePolicyService()
+	if diags.HasError() {
+		return diags
+	}
+
+	chromePoliciesService, diags := GetChromePoliciesService(chromePolicyService)
+	if diags.HasError() {
+		return diags
+	}
+
+	targetID := strings.TrimPrefix(d.Get(idAttr).(string), "id:")
+
+	log.Printf("[DEBUG] Creating Chrome Policy for %s:%s", kind, targetID)
+
+	policyTargetKey := &chromepolicy.GoogleChromePolicyV1PolicyTargetKey{
+		TargetResource: string(kind) + "/" + targetID,
+	}
+
+	if _, ok := d.GetOk("additional_target_keys"); ok {
+		policyTargetKey.AdditionalTargetKeys = expandChromePoliciesAdditionalTargetKeys(d.Get("additional_target_keys").([]interface{}))
+	}
+
+	diags = validateChromePolicies(ctx, d, client)
+	if diags.HasError() {
+		return diags
+	}
+
+	policies, diags := expandChromePoliciesValues(d.Get("policies").([]interface{}))
+	if diags.HasError() {
+		return diags
+	}
+
+	var requests []*chromepolicy.GoogleChromePolicyV1ModifyOrgUnitPolicyRequest
+	for _, p := range policies {
+		var keys []string
+		var schemaValues map[string]interface{}
+		if err := json.Unmarshal(p.Value, &schemaValues); err != nil {
+			return diag.FromErr(err)
+		}
+		for key := range schemaValues {
+			keys = append(keys, key)
+		}
+		requests = append(requests, &chromepolicy.GoogleChromePolicyV1ModifyOrgUnitPolicyRequest{
+			PolicyTargetKey: policyTargetKey,
+			PolicyValue:     p,
+			UpdateMask:      strings.Join(keys, ","),
+		})
+	}
+
+	err := retryTimeDuration(ctx, time.Minute, func() error {
+		_, retryErr := chromePoliciesService.Orgunits.BatchModify(fmt.Sprintf("customers/%s", client.Customer), &chromepolicy.GoogleChromePolicyV1BatchModifyOrgUnitPoliciesRequest{Requests: requests}).Do()
+		return retryErr
+	})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[DEBUG] Finished creating Chrome Policy for %s:%s", kind, targetID)
+	d.SetId(targetID)
+
+	return chromePolicyReadCommon(ctx, d, meta, kind)
+}
+
+// chromePolicyUpdateCommon performs the inherit-then-create update pattern shared by both resources.
+func chromePolicyUpdateCommon(ctx context.Context, d *schema.ResourceData, meta interface{}, kind chromePolicyTargetKind) diag.Diagnostics {
+	client := meta.(*apiClient)
+
+	chromePolicyService, diags := client.NewChromePolicyService()
+	if diags.HasError() {
+		return diags
+	}
+
+	chromePoliciesService, diags := GetChromePoliciesService(chromePolicyService)
+	if diags.HasError() {
+		return diags
+	}
+
+	log.Printf("[DEBUG] Updating Chrome Policy for %s:%s", kind, d.Id())
+
+	policyTargetKey := &chromepolicy.GoogleChromePolicyV1PolicyTargetKey{
+		TargetResource: string(kind) + "/" + d.Id(),
+	}
+
+	if _, ok := d.GetOk("additional_target_keys"); ok {
+		policyTargetKey.AdditionalTargetKeys = expandChromePoliciesAdditionalTargetKeys(d.Get("additional_target_keys").([]interface{}))
+	}
+
+	old, _ := d.GetChange("policies")
+
+	var requests []*chromepolicy.GoogleChromePolicyV1InheritOrgUnitPolicyRequest
+	for _, p := range old.([]interface{}) {
+		policy := p.(map[string]interface{})
+		schemaName := policy["schema_name"].(string)
+
+		requests = append(requests, &chromepolicy.GoogleChromePolicyV1InheritOrgUnitPolicyRequest{
+			PolicyTargetKey: policyTargetKey,
+			PolicySchema:    schemaName,
+		})
+	}
+
+	err := retryTimeDuration(ctx, time.Minute, func() error {
+		_, retryErr := chromePoliciesService.Orgunits.BatchInherit(fmt.Sprintf("customers/%s", client.Customer), &chromepolicy.GoogleChromePolicyV1BatchInheritOrgUnitPoliciesRequest{Requests: requests}).Do()
+		return retryErr
+	})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// Re-run create logic to apply the new set.
+	diags = chromePolicyCreateCommon(ctx, d, meta, kind, idAttributeForKind(kind))
+	if diags.HasError() {
+		return diags
+	}
+
+	log.Printf("[DEBUG] Finished updating Chrome Policy for %s:%s", kind, d.Id())
+	return diags
+}
+
+// chromePolicyReadCommon reads policies for both target kinds.
+func chromePolicyReadCommon(ctx context.Context, d *schema.ResourceData, meta interface{}, kind chromePolicyTargetKind) diag.Diagnostics {
+	client := meta.(*apiClient)
+
+	chromePolicyService, diags := client.NewChromePolicyService()
+	if diags.HasError() {
+		return diags
+	}
+
+	chromePoliciesService, diags := GetChromePoliciesService(chromePolicyService)
+	if diags.HasError() {
+		return diags
+	}
+
+	log.Printf("[DEBUG] Getting Chrome Policy for %s:%s", kind, d.Id())
+
+	policyTargetKey := &chromepolicy.GoogleChromePolicyV1PolicyTargetKey{
+		TargetResource: string(kind) + "/" + d.Id(),
+	}
+
+	if _, ok := d.GetOk("additional_target_keys"); ok {
+		policyTargetKey.AdditionalTargetKeys = expandChromePoliciesAdditionalTargetKeys(d.Get("additional_target_keys").([]interface{}))
+	}
+
+	policiesObj := []*chromepolicy.GoogleChromePolicyV1PolicyValue{}
+	for _, p := range d.Get("policies").([]interface{}) {
+		policy := p.(map[string]interface{})
+		schemaName := policy["schema_name"].(string)
+
+		var resp *chromepolicy.GoogleChromePolicyV1ResolveResponse
+		err := retryTimeDuration(ctx, time.Minute, func() error {
+			var retryErr error
+			resp, retryErr = chromePoliciesService.Resolve(fmt.Sprintf("customers/%s", client.Customer), &chromepolicy.GoogleChromePolicyV1ResolveRequest{
+				PolicySchemaFilter: schemaName,
+				PolicyTargetKey:    policyTargetKey,
+			}).Do()
+			return retryErr
+		})
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		if len(resp.ResolvedPolicies) != 1 {
+			return diag.Errorf("unexpected number of resolved policies for schema: %s", schemaName)
+		}
+
+		value := resp.ResolvedPolicies[0].Value
+		policiesObj = append(policiesObj, value)
+	}
+
+	policies, diags := flattenChromePolicies(ctx, policiesObj, client)
+	if diags.HasError() {
+		return diags
+	}
+
+	if err := d.Set("policies", policies); err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[DEBUG] Finished getting Chrome Policy for %s:%s", kind, d.Id())
+	return nil
+}
+
+// chromePolicyDeleteCommon deletes policies for both target kinds.
+func chromePolicyDeleteCommon(ctx context.Context, d *schema.ResourceData, meta interface{}, kind chromePolicyTargetKind) diag.Diagnostics {
+	client := meta.(*apiClient)
+
+	chromePolicyService, diags := client.NewChromePolicyService()
+	if diags.HasError() {
+		return diags
+	}
+
+	chromePoliciesService, diags := GetChromePoliciesService(chromePolicyService)
+	if diags.HasError() {
+		return diags
+	}
+
+	log.Printf("[DEBUG] Deleting Chrome Policy for %s:%s", kind, d.Id())
+
+	policyTargetKey := &chromepolicy.GoogleChromePolicyV1PolicyTargetKey{
+		TargetResource: string(kind) + "/" + d.Id(),
+	}
+
+	if _, ok := d.GetOk("additional_target_keys"); ok {
+		policyTargetKey.AdditionalTargetKeys = expandChromePoliciesAdditionalTargetKeys(d.Get("additional_target_keys").([]interface{}))
+	}
+
+	var requests []*chromepolicy.GoogleChromePolicyV1InheritOrgUnitPolicyRequest
+	for _, p := range d.Get("policies").([]interface{}) {
+		policy := p.(map[string]interface{})
+		schemaName := policy["schema_name"].(string)
+		requests = append(requests, &chromepolicy.GoogleChromePolicyV1InheritOrgUnitPolicyRequest{
+			PolicyTargetKey: policyTargetKey,
+			PolicySchema:    schemaName,
+		})
+	}
+
+	err := retryTimeDuration(ctx, time.Minute, func() error {
+		_, retryErr := chromePoliciesService.Orgunits.BatchInherit(fmt.Sprintf("customers/%s", client.Customer), &chromepolicy.GoogleChromePolicyV1BatchInheritOrgUnitPoliciesRequest{Requests: requests}).Do()
+		return retryErr
+	})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[DEBUG] Finished deleting Chrome Policy for %s:%s", kind, d.Id())
+	return nil
+}
+
+// helper to map kind to attribute name
+func idAttributeForKind(kind chromePolicyTargetKind) string {
+	switch kind {
+	case targetOrgUnit:
+		return "org_unit_id"
+	case targetGroup:
+		return "group_id"
+	default:
+		return "id" // fallback; should not occur
+	}
+}

--- a/internal/provider/chrome_policy_common_test.go
+++ b/internal/provider/chrome_policy_common_test.go
@@ -1,0 +1,138 @@
+package googleworkspace
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestIdAttributeForKind_Common(t *testing.T) {
+	cases := []struct {
+		name     string
+		kind     chromePolicyTargetKind
+		expected string
+	}{
+		{"orgunit", targetOrgUnit, "org_unit_id"},
+		{"group", targetGroup, "group_id"},
+		{"fallback", chromePolicyTargetKind("something_else"), "id"},
+	}
+
+	for _, c := range cases {
+		if got := idAttributeForKind(c.kind); got != c.expected {
+			t.Errorf("%s: expected %s got %s", c.name, c.expected, got)
+		}
+	}
+}
+
+func TestChromePolicyTargetKindString(t *testing.T) {
+	if string(targetOrgUnit) != "orgunits" {
+		t.Errorf("targetOrgUnit constant changed: %s", string(targetOrgUnit))
+	}
+	if string(targetGroup) != "groups" {
+		t.Errorf("targetGroup constant changed: %s", string(targetGroup))
+	}
+}
+
+func TestValidatePolicyFieldValueType(t *testing.T) {
+	cases := []struct {
+		fieldType string
+		value     interface{}
+		expect    bool
+	}{
+		{"TYPE_BOOL", true, true},
+		{"TYPE_BOOL", "true", false},
+		{"TYPE_DOUBLE", 1.23, true},
+		{"TYPE_INT64", float64(10), true},
+		{"TYPE_INT64", float64(10.5), false},
+		{"TYPE_STRING", "abc", true},
+		{"TYPE_ENUM", "SOME_ENUM", true},
+		{"TYPE_MESSAGE", map[string]interface{}{"k": "v"}, true},
+		{"TYPE_MESSAGE", []string{"x"}, false},
+		{"TYPE_UINT32", float32(3), true},
+		{"TYPE_UINT32", float32(3.1), false},
+	}
+	for _, c := range cases {
+		if got := validatePolicyFieldValueType(c.fieldType, c.value); got != c.expect {
+			t.Errorf("validatePolicyFieldValueType(%s,%v) expected %v got %v", c.fieldType, c.value, c.expect, got)
+		}
+	}
+}
+
+func TestConvertPolicyFieldValueType(t *testing.T) {
+	cases := []struct {
+		fieldType string
+		in        interface{}
+		want      interface{}
+		wantErr   bool
+	}{
+		{"TYPE_BOOL", "true", true, false},
+		{"TYPE_BOOL", "notbool", nil, true},
+		{"TYPE_DOUBLE", "1.25", float64(1.25), false},
+		{"TYPE_INT64", "42", int64(42), false},
+		{"TYPE_INT64", "4.2", nil, true},
+		{"TYPE_UINT32", "7", int64(7), false},
+		{"TYPE_STRING", "abc", "abc", false},
+		{"TYPE_ENUM", "ENUM_VAL", "ENUM_VAL", false},
+	}
+	for _, c := range cases {
+		got, err := convertPolicyFieldValueType(c.fieldType, c.in)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("expected error for %s input %v", c.fieldType, c.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("unexpected error for %s input %v: %v", c.fieldType, c.in, err)
+			continue
+		}
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("convertPolicyFieldValueType(%s,%v) expected %v got %v", c.fieldType, c.in, c.want, got)
+		}
+	}
+}
+
+func TestExpandChromePoliciesAdditionalTargetKeys(t *testing.T) {
+	in := []interface{}{
+		map[string]interface{}{"target_key": "app_id", "target_value": "chrome:abc"},
+		map[string]interface{}{"target_key": "profile_id", "target_value": "def"},
+	}
+	got := expandChromePoliciesAdditionalTargetKeys(in)
+	if got["app_id"] != "chrome:abc" || got["profile_id"] != "def" || len(got) != 2 {
+		t.Errorf("unexpected map result: %#v", got)
+	}
+}
+
+func TestExpandChromePoliciesValues(t *testing.T) {
+	input := []interface{}{map[string]interface{}{
+		"schema_name": "chrome.users.MaxConnectionsPerProxy",
+		"schema_values": map[string]interface{}{
+			"maxConnectionsPerProxy": jsonMustMarshalToString(8),
+		},
+	}}
+	vals, diags := expandChromePoliciesValues(input)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %#v", diags)
+	}
+	if len(vals) != 1 {
+		t.Fatalf("expected 1 policy value, got %d", len(vals))
+	}
+	if vals[0].PolicySchema != "chrome.users.MaxConnectionsPerProxy" {
+		t.Errorf("unexpected schema name: %s", vals[0].PolicySchema)
+	}
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(vals[0].Value, &decoded); err != nil {
+		t.Fatalf("error unmarshalling stored value: %v", err)
+	}
+	if decoded["maxConnectionsPerProxy"].(float64) != 8 { // JSON numbers become float64
+		t.Errorf("expected stored numeric value 8, got %#v", decoded["maxConnectionsPerProxy"])
+	}
+}
+
+func jsonMustMarshalToString(v interface{}) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -130,6 +130,7 @@ func New(version string) func() *schema.Provider {
 			},
 			ResourcesMap: map[string]*schema.Resource{
 				"googleworkspace_chrome_policy":       resourceChromePolicy(),
+				"googleworkspace_chrome_group_policy": resourceChromeGroupPolicy(),
 				"googleworkspace_domain":              resourceDomain(),
 				"googleworkspace_domain_alias":        resourceDomainAlias(),
 				"googleworkspace_gmail_send_as_alias": resourceGmailSendAsAlias(),

--- a/internal/provider/resource_chrome_group_policy.go
+++ b/internal/provider/resource_chrome_group_policy.go
@@ -1,0 +1,91 @@
+package googleworkspace
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceChromeGroupPolicy() *schema.Resource {
+	return &schema.Resource{
+		Description: "Chrome Policy resource in the Terraform Googleworkspace provider. " +
+			"Chrome Policy Schema resides under the `https://www.googleapis.com/auth/chrome.management.policy` client scope.",
+
+		CreateContext: resourceChromeGroupPolicyCreate,
+		UpdateContext: resourceChromeGroupPolicyUpdate,
+		ReadContext:   resourceChromeGroupPolicyRead,
+		DeleteContext: resourceChromeGroupPolicyDelete,
+
+		Schema: map[string]*schema.Schema{
+			"group_id": {
+				Description: "The target group on which this policy is applied.",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+			},
+			"additional_target_keys": {
+				Description: "Additional target keys for policies.",
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"target_key": {
+							Description: "The target key name.",
+							Type:        schema.TypeString,
+							Required:    true,
+						},
+						"target_value": {
+							Description: "The target key value.",
+							Type:        schema.TypeString,
+							Required:    true,
+						},
+					},
+				},
+			},
+			"policies": {
+				Description: "Policies to set for the org unit",
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"schema_name": {
+							Description: "The full qualified name of the policy schema.",
+							Type:        schema.TypeString,
+							Required:    true,
+						},
+						"schema_values": {
+							Description: "JSON encoded map that represents key/value pairs that " +
+								"correspond to the given schema. ",
+							Type:     schema.TypeMap,
+							Required: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+								ValidateDiagFunc: validation.ToDiagFunc(
+									validation.StringIsJSON,
+								),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceChromeGroupPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return chromePolicyCreateCommon(ctx, d, meta, targetGroup, "group_id")
+}
+
+func resourceChromeGroupPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return chromePolicyUpdateCommon(ctx, d, meta, targetGroup)
+}
+
+func resourceChromeGroupPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return chromePolicyReadCommon(ctx, d, meta, targetGroup)
+}
+
+func resourceChromeGroupPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return chromePolicyDeleteCommon(ctx, d, meta, targetGroup)
+}

--- a/internal/provider/resource_chrome_group_policy_test.go
+++ b/internal/provider/resource_chrome_group_policy_test.go
@@ -1,0 +1,370 @@
+package googleworkspace
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"google.golang.org/api/chromepolicy/v1"
+)
+
+// (idAttributeForKind tests moved to chrome_policy_common_test.go)
+
+func TestAccResourceChromeGroupPolicy_basic(t *testing.T) {
+	t.Parallel()
+
+	groupName := fmt.Sprintf("tf-test-group-%s", acctest.RandString(6))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceChromeGroupPolicy_basic(groupName, 7),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.#", "1"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.0.schema_name", "chrome.users.MaxConnectionsPerProxy"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.0.schema_values.maxConnectionsPerProxy", "7"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceChromeGroupPolicy_typeMessage(t *testing.T) {
+	t.Parallel()
+
+	groupName := fmt.Sprintf("tf-test-group-%s", acctest.RandString(6))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceChromeGroupPolicy_typeMessage(groupName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.#", "1"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.0.schema_name", "chrome.users.ManagedBookmarksSetting"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.0.schema_values.managedBookmarks", "{\"toplevelName\":\"Stuff\"}"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceChromeGroupPolicy_additionalTargetKey(t *testing.T) {
+	t.Parallel()
+
+	groupName := fmt.Sprintf("tf-test-group-%s", acctest.RandString(6))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceChromeGroupPolicy_additionalTargetKey(groupName, "chrome:glnpjglilkicbckjpbgcfkogebgllemb", "ALLOWED"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.#", "1"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.0.schema_name", "chrome.users.apps.InstallType"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.0.schema_values.appInstallType", encode("ALLOWED")),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "additional_target_keys.#", "1"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "additional_target_keys.0.target_key", "app_id"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "additional_target_keys.0.target_value", "chrome:glnpjglilkicbckjpbgcfkogebgllemb"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceChromeGroupPolicy_update(t *testing.T) {
+	t.Parallel()
+
+	groupName := fmt.Sprintf("tf-test-group-%s", acctest.RandString(6))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceChromeGroupPolicy_basic(groupName, 5),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.#", "1"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.0.schema_name", "chrome.users.MaxConnectionsPerProxy"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.0.schema_values.maxConnectionsPerProxy", "5"),
+				),
+			},
+			{
+				Config: testAccResourceChromeGroupPolicy_basic(groupName, 9),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.#", "1"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.0.schema_name", "chrome.users.MaxConnectionsPerProxy"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.0.schema_values.maxConnectionsPerProxy", "9"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceChromeGroupPolicy_multiple(t *testing.T) {
+	t.Parallel()
+
+	groupName := fmt.Sprintf("tf-test-group-%s", acctest.RandString(6))
+
+	// ensures previously set field was reset/removed
+	testCheck := func(s *terraform.State) error {
+		client, err := googleworkspaceTestClient()
+		if err != nil {
+			return err
+		}
+
+		rs, ok := s.RootModule().Resources["googleworkspace_group.test"]
+		if !ok {
+			return fmt.Errorf("Can't find group resource: googleworkspace_group.test")
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("group ID not set")
+		}
+
+		chromePolicyService, diags := client.NewChromePolicyService()
+		if diags.HasError() {
+			return errors.New(diags[0].Summary)
+		}
+
+		chromePoliciesService, diags := GetChromePoliciesService(chromePolicyService)
+		if diags.HasError() {
+			return errors.New(diags[0].Summary)
+		}
+
+		policyTargetKey := &chromepolicy.GoogleChromePolicyV1PolicyTargetKey{
+			TargetResource: "groups/" + strings.TrimPrefix(rs.Primary.ID, "id:"),
+		}
+
+		resp, err := chromePoliciesService.Resolve(fmt.Sprintf("customers/%s", client.Customer), &chromepolicy.GoogleChromePolicyV1ResolveRequest{
+			PolicySchemaFilter: "chrome.users.MaxConnectionsPerProxy",
+			PolicyTargetKey:    policyTargetKey,
+		}).Do()
+		if err != nil {
+			return err
+		}
+		if len(resp.ResolvedPolicies) > 0 {
+			return fmt.Errorf("Expected policy to be reset")
+		}
+		return nil
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceChromeGroupPolicy_multiple(groupName, 3, ".*@example"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.#", "2"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.0.schema_name", "chrome.users.RestrictSigninToPattern"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.0.schema_values.restrictSigninToPattern", encode(".*@example")),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.1.schema_name", "chrome.users.MaxConnectionsPerProxy"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.1.schema_values.maxConnectionsPerProxy", "3"),
+				),
+			},
+			{
+				Config: testAccResourceChromeGroupPolicy_multipleRearranged(groupName, 4, ".*@example.com"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.#", "2"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.0.schema_name", "chrome.users.MaxConnectionsPerProxy"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.0.schema_values.maxConnectionsPerProxy", "4"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.1.schema_name", "chrome.users.RestrictSigninToPattern"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.1.schema_values.restrictSigninToPattern", encode(".*@example.com")),
+				),
+			},
+			{
+				Config: testAccResourceChromeGroupPolicy_multipleDifferent(groupName, true, ".*@example.com"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.#", "2"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.0.schema_name", "chrome.users.OnlineRevocationChecks"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.0.schema_values.enableOnlineRevocationChecks", "true"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.1.schema_name", "chrome.users.RestrictSigninToPattern"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.1.schema_values.restrictSigninToPattern", encode(".*@example.com")),
+					testCheck,
+				),
+			},
+			{
+				Config: testAccResourceChromeGroupPolicy_multipleValueTypes(groupName, true, "POLICY_MODE_RECOMMENDED"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.#", "1"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.0.schema_name", "chrome.users.DomainReliabilityAllowed"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.0.schema_values.domainReliabilityAllowed", "true"),
+					resource.TestCheckResourceAttr("googleworkspace_chrome_group_policy.test", "policies.0.schema_values.domainReliabilityAllowedSettingGroupPolicyMode", encode("POLICY_MODE_RECOMMENDED")),
+					testCheck,
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceChromeGroupPolicy_basic(groupName string, conns int) string {
+	return fmt.Sprintf(`
+resource "googleworkspace_group" "test" {
+  email       = "%s@example.com"
+  name        = "%s"
+  description = "Test group"
+}
+
+resource "googleworkspace_chrome_group_policy" "test" {
+  group_id = googleworkspace_group.test.id
+  policies {
+    schema_name = "chrome.users.MaxConnectionsPerProxy"
+    schema_values = {
+      maxConnectionsPerProxy = jsonencode(%d)
+    }
+  }
+}
+`, groupName, groupName, conns)
+}
+
+func testAccResourceChromeGroupPolicy_typeMessage(groupName string) string {
+	return fmt.Sprintf(`
+resource "googleworkspace_group" "test" {
+  email       = "%s@example.com"
+  name        = "%s"
+  description = "Test group"
+}
+
+resource "googleworkspace_chrome_group_policy" "test" {
+  group_id = googleworkspace_group.test.id
+  policies {
+    schema_name = "chrome.users.ManagedBookmarksSetting"
+    schema_values = {
+      managedBookmarks = "{\"toplevelName\":\"Stuff\"}"
+    }
+  }
+}
+`, groupName, groupName)
+}
+
+func testAccResourceChromeGroupPolicy_additionalTargetKey(groupName, appID, installType string) string {
+	return fmt.Sprintf(`
+resource "googleworkspace_group" "test" {
+  email       = "%s@example.com"
+  name        = "%s"
+  description = "Test group"
+}
+
+resource "googleworkspace_chrome_group_policy" "test" {
+  group_id = googleworkspace_group.test.id
+  additional_target_keys {
+    target_key   = "app_id"
+    target_value = "%s"
+  }
+  policies {
+    schema_name = "chrome.users.apps.InstallType"
+    schema_values = {
+      appInstallType = jsonencode("%s")
+    }
+  }
+}
+`, groupName, groupName, appID, installType)
+}
+
+func testAccResourceChromeGroupPolicy_multiple(groupName string, conns int, pattern string) string {
+	return fmt.Sprintf(`
+resource "googleworkspace_group" "test" {
+  email       = "%s@example.com"
+  name        = "%s"
+  description = "Test group"
+}
+
+resource "googleworkspace_chrome_group_policy" "test" {
+  group_id = googleworkspace_group.test.id
+  policies {
+    schema_name = "chrome.users.RestrictSigninToPattern"
+    schema_values = {
+      restrictSigninToPattern = jsonencode("%s")
+    }
+  }
+  policies {
+    schema_name = "chrome.users.MaxConnectionsPerProxy"
+    schema_values = {
+      maxConnectionsPerProxy = jsonencode(%d)
+    }
+  }
+}
+`, groupName, groupName, pattern, conns)
+}
+
+func testAccResourceChromeGroupPolicy_multipleRearranged(groupName string, conns int, pattern string) string {
+	return fmt.Sprintf(`
+resource "googleworkspace_group" "test" {
+  email       = "%s@example.com"
+  name        = "%s"
+  description = "Test group"
+}
+
+resource "googleworkspace_chrome_group_policy" "test" {
+  group_id = googleworkspace_group.test.id
+  policies {
+    schema_name = "chrome.users.MaxConnectionsPerProxy"
+    schema_values = {
+      maxConnectionsPerProxy = jsonencode(%d)
+    }
+  }
+  policies {
+    schema_name = "chrome.users.RestrictSigninToPattern"
+    schema_values = {
+      restrictSigninToPattern = jsonencode("%s")
+    }
+  }
+}
+`, groupName, groupName, conns, pattern)
+}
+
+func testAccResourceChromeGroupPolicy_multipleDifferent(groupName string, enabled bool, pattern string) string {
+	return fmt.Sprintf(`
+resource "googleworkspace_group" "test" {
+  email       = "%s@example.com"
+  name        = "%s"
+  description = "Test group"
+}
+
+resource "googleworkspace_chrome_group_policy" "test" {
+  group_id = googleworkspace_group.test.id
+  policies {
+    schema_name = "chrome.users.OnlineRevocationChecks"
+    schema_values = {
+      enableOnlineRevocationChecks = jsonencode(%t)
+    }
+  }
+  policies {
+    schema_name = "chrome.users.RestrictSigninToPattern"
+    schema_values = {
+      restrictSigninToPattern = jsonencode("%s")
+    }
+  }
+}
+`, groupName, groupName, enabled, pattern)
+}
+
+func testAccResourceChromeGroupPolicy_multipleValueTypes(groupName string, enabled bool, policyMode string) string {
+	return fmt.Sprintf(`
+resource "googleworkspace_group" "test" {
+  email       = "%s@example.com"
+  name        = "%s"
+  description = "Test group"
+}
+
+resource "googleworkspace_chrome_group_policy" "test" {
+  group_id = googleworkspace_group.test.id
+  policies {
+    schema_name = "chrome.users.DomainReliabilityAllowed"
+    schema_values = {
+      domainReliabilityAllowed                       = jsonencode(%t)
+      domainReliabilityAllowedSettingGroupPolicyMode = jsonencode("%s")
+    }
+  }
+}
+`, groupName, groupName, enabled, policyMode)
+}


### PR DESCRIPTION
This PR adds a new resource for `googleworkspace_chrome_group_policy` - I decided on a new resource rather than add group support to `googleworkspace_chrome_policy` so I didn't need to re-engineer detecting duplicate targets.

I'm not 100% sure how to test this for real (any pointers would be appreciated), but it passes unit tests, so I'm farily confident that it will work.